### PR TITLE
Updated Dockerfile with instructions to ROS 2 Humble-based Open-RMF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,35 @@
-FROM ghcr.io/sharp-rmf/rmf-deployment/builder-rmf
-ARG GIT_VER=main
-WORKDIR /opt/rmf/src
-
-SHELL ["/bin/bash", "-c"]
-RUN echo 'Checking out GIT version of repo:' {$GIT_VER}
-RUN git clone https://github.com/sharp-rmf/kone-ros-api.git && cd kone-ros-api && git checkout $GIT_VER
+FROM ros:humble-ros-base
 
 WORKDIR /opt/rmf
 
+# Install dependencies
 RUN apt-get update && apt-get install -y python3-pip && \
-  pip3 install websocket websockets websocket-client requests
+    pip3 install websockets websocket-client requests
 
-# install
-RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-  apt-get update && rosdep install -y \
-  --from-paths \
-  src/kone-ros-api \
-  --ignore-src \
-  && rm -rf /var/lib/apt/lists/*
+# Clone the repository
+WORKDIR /opt/rmf/src
+RUN mkdir -p /kone-ros-api
 
-# Build
-RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-  colcon build --packages-select kone_ros_api
+RUN git clone https://github.com/open-rmf/rmf_internal_msgs.git --branch main --single-branch --depth 1
+COPY . kone-ros-api/
 
-RUN sed -i '$iros2 run kone_ros_api koneNode_v2' /ros_entrypoint.sh
+# Verify the contents
+RUN ls -la /opt/rmf/src/kone-ros-api
 
+# Setup the workspace
+WORKDIR /opt/rmf
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && apt-get update && rosdep update --rosdistro $ROS_DISTRO
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && rosdep install -y --from-paths /opt/rmf/src/kone-ros-api --ignore-src
+
+# Build the workspace
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && colcon build --packages-select kone_ros_api && colcon build --packages-select rmf_lift_msgs
+
+# Ensure the entrypoint script sources the ROS setup
+RUN echo 'source /opt/rmf/install/setup.bash' >> /ros_entrypoint.sh
+
+# Ensure proper permissions for entrypoint
+RUN chmod +x /ros_entrypoint.sh
+
+WORKDIR /opt/rmf/
 ENTRYPOINT ["/ros_entrypoint.sh"]
-CMD ["bash"]
+

--- a/README.md
+++ b/README.md
@@ -46,11 +46,28 @@ source YOUR_RMF_Lift_MSG_WORKSPACE (eg. source ~/rmf_ws/install/setup.bash)
 colcon build
 ```
 ## Dockerfile
-To quickly start running your own Kone RMF Lift Adapter with the Kone v2 API. Simply copy the docker file out, build it, and run it with the correct env.yaml file (which contains the secrets).
+Follow the instructions below to quickly start running your own Kone RMF Lift Adapter with the Kone v2 API.
+
+Download this repository, build it, and run it with the correct `env.yaml` file (which contains the secrets).
+
 > If you get a <code>KeyError: 'access_token'</code> error, please check that your env.yaml's <code>access_id/access_secret</code> is correct.
+
+```bash
+git clone https://github.com/chart-sg/lift_kone_adapter.git --branch main --single-branch --depth 1 && cd lift_kone_adapter
 ```
-docker build -f src/kone-ros-api/Dockerfile -t kone --build-arg GIT_VER=6e75d1c18d1132bf8bacd51b1fee29ee9b2dab42 . # To checkout git commit 6e75d1
-docker run -it --network host --mount type=bind,source=$PWD/src/kone-ros-api/config/env.yaml,destination=/opt/rmf/install/kone_ros_api/share/kone_ros_api/config/env.yaml kone:latest /bin/bash
+
+```bash
+docker build -t lift_kone_adapter .
+```
+
+```bash
+docker run -it --rm \
+    --name lift_adapter_kone_c \
+    --network host \
+    -v /dev/shm:/dev/shm \
+    -v ./config/env.yaml:/opt/rmf/install/kone_ros_api/share/kone_ros_api/config/env.yaml \
+    lift_adapter_kone:latest /bin/bash -c \
+    "source install/setup.bash && ros2 run kone_ros_api koneNode_v2"
 ```
 
 ## Fill up the config/env.yaml before you run this package

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Things to take note for KONE API v2.0:
 2. Liftstate websocket will be closed by KONE Server if it has been opened for more than 300s (5 minutes). That's why koneNode reopens the liftstate websocket for every 300s.
 3. Liftstate websocket will be closed by KONE Server if inactive for 60s (1 minute). That's why koneNode reopens the liftstate websocket if it is inactive for more than 60s.
 
-## Useful links:
+## Useful Links:
 1. Robotics Middleware Framework (RMF): https://github.com/open-rmf/rmf
 2. KONE API v2.0: https://dev.kone.com/api-portal/dashboard/api-documentation/elevator-websocket-api-v2
 
@@ -146,9 +146,9 @@ Things to take note for KONE API v2.0:
    [scope]: <https://dev.kone.com/api-portal/dashboard/developer-guide/overview-api#scopes>
    [door holding time]: <https://dev.kone.com/api-portal/dashboard/api-documentation/elevator-websocket-api-v2/robots#hold-car-door-open>
    [authentication request]: <https://dev.kone.com/api-portal/dashboard/api-documentation/elevator-websocket-api-v2/robots#authentication>
-   [koneAdapter_v2.py]: <https://github.com/sharp-rmf/kone-ros-api/blob/main/kone_ros_api/koneAdaptor_v2.py>
-   [koneNode_v2.py]: <https://github.com/sharp-rmf/kone-ros-api/blob/main/kone_ros_api/koneNode_v2.py>
-   [env.yaml]: <https://github.com/sharp-rmf/kone-ros-api/blob/main/config/env.yaml>
+   [koneAdapter_v2.py]: <https://github.com/chart-sg/lift_kone_adapter/blob/main/kone_ros_api/koneAdaptor_v2.py>
+   [koneNode_v2.py]: <https://github.com/chart-sg/lift_kone_adapter/blob/main/kone_ros_api/koneNode_v2.py>
+   [env.yaml]: <https://github.com/chart-sg/lift_kone_adapter/blob/main/config/env.yaml>
    [The Galen]: <https://www.capitaland.com/en/find-a-property/global-property-listing/businesspark-industrial-logistics/the-galen.html>
    [/lift_requests]: <https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/msg/LiftRequest.msg>
    [/lift_states]: <https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_lift_msgs/msg/LiftState.msg>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This package has been tested to be working on:
 ## Installation
 ```
 mkdir -p kone_ros_api_ws/src
-git clone https://github.com/sharp-rmf/kone-ros-api.git
+git clone https://github.com/chart-sg/lift_kone_adapter.git
 cd ..
 source YOUR_RMF_Lift_MSG_WORKSPACE (eg. source ~/rmf_ws/install/setup.bash)
 colcon build

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ The following are packages/messages required by the adapter:
 - Python module: threading, requests, websocket, json
 
 This package has been tested to be working on:
-- Ubuntu 20.04
-- [ROS2 Galactic]
+- Ubuntu `22.04`
+- [ROS2 Humble]
 
 ## Installation
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This package has been tested to be working on:
 ## Installation
 ```
 mkdir -p kone_ros_api_ws/src
-git clone https://github.com/chart-sg/lift_kone_adapter.git
+git clone https://github.com/chart-sg/lift_kone_adapter.git --branch main --single-branch --depth 1
 cd ..
 source YOUR_RMF_Lift_MSG_WORKSPACE (eg. source ~/rmf_ws/install/setup.bash)
 colcon build


### PR DESCRIPTION
## **What Is This For?**

This pull request is to update the root `Dockerfile` as well as corresponding instructions on root `README.md` to use **ROS 2 Humble-based Open-RMF**, as opposed to current **ROS2 2 Galactic-based Open RMF**:

[Open-RMF on Humble Hawksbill - Sync (2023-12-29)](https://github.com/open-rmf/rmf/releases/tag/release-humble-231229)

## **Summary** :bookmark_tabs: 
- `Dockerfile` uses `ros:humble-ros-base` as a docker image base for better fixed dependency network.
- `Dockerfile` uses local implement of `kone_lift_adapter` instead of remote counterpart for easier development going forward.
- `README.md` updated to reflect proper use of new `Dockerfile`.
- `README.md` legacy `sharp-rmf`-related links updated to reflect current `chart-sg` links. Verified legacy links.